### PR TITLE
Option for memory (RAM) usage for r.watershed

### DIFF
--- a/m.swim.subbasins/m.swim.subbasins.py
+++ b/m.swim.subbasins/m.swim.subbasins.py
@@ -224,6 +224,17 @@
 #% answer: s
 #%end
 
+#%Option
+#% guisection: Optional
+#% key: rwatershedmem
+#% type: integer
+#% required: no
+#% multiple: no
+#% key_desc: integer
+#% description: Memory usage by r.watershed in MB
+#% answer: 1000
+#%end
+
 #%Flag
 #% guisection: Optional
 #% key: s
@@ -236,7 +247,7 @@
 #% label: Keep intermediat files (include __ in names)
 #%end
 
-import os, sys
+import sys
 import grass.script as grass
 g_run=grass.run_command
 gm   = grass.message
@@ -292,6 +303,9 @@ class main:
         # if no r.watershed flags given
         if 'rwatershedflags' not in self.options: self.rwatershedflags='s'
 
+        # if no r.watershed memory usage is given, set to default
+        if 'rwatershedmem' not in self.options: self.rwatershedmem=300
+
         # check input for stats print
         if self.s:
             for o in ['streams','stations','catchmentprefix']:
@@ -330,7 +344,8 @@ class main:
                   'basin'       : 'standard__subbasins',
                   'slope_steepness': self.slopesteepness,
                   'length_slope': self.slopelength,
-                  'flags'       : self.rwatershedflags}
+                  'flags'       : self.rwatershedflags, 
+                  'memory'      : self.rwatershedmem}
         # check if depressions
         if 'depression' in self.options: kwargs['depression']=self.depression
 
@@ -481,7 +496,8 @@ class main:
                 kwargs ={'elevation': self.elevation,
                          'basin'    : subbasins_uncut,
                          'threshold': thresh,
-                         'flags'    : self.rwatershedflags}
+                         'flags'    : self.rwatershedflags,
+                         'memory'   : self.rwatershedmem}
                 # carved elevation
                 if 'streamcarve' in self.options:
                     kwargs['elevation']=self.carvedelevation

--- a/test/test_subbasins.grass
+++ b/test/test_subbasins.grass
@@ -6,7 +6,7 @@ module=../m.swim.subbasins/m.swim.subbasins.py
 
 # basic subbasins
 $module elevation=elevation@PERMANENT stations=stations@PERMANENT \
-                 upthresh=40 lothresh=11 subbasins=subbasins
+                 upthresh=40 lothresh=11 subbasins=subbasins rwatershedmem=400
 
 # subbasins with carved streams 
 # catchment 2 has very small catchment/no subbasins


### PR DESCRIPTION
The default memory (RAM) limit for r.watershed is pretty low by default.
With this option, the RAM usage can be set in order to use the full
power of the current machine.